### PR TITLE
docs: add ops terminal principle

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,6 +46,21 @@ Why this matters:
 - **Lower overhead**: Fewer manual recaps and less prompt rework.
 - **Team leverage**: Share context safely across collaborators or environments.
 
+### 5. Bloomberg-Style Ops Terminal
+
+**Athena should be the command-and-control terminal for engineering.**
+
+The interface should converge project management, CI/CD, agent activity,
+scheduling, and context insights into one ops view, while integrations fan out
+to Jira/Linear and other systems. Context intelligence (summaries, embeddings,
+data signals) should surface inline with operational decisions.
+
+Why this matters:
+- **One console**: Fewer tool hops and less context switching.
+- **Faster ops**: CI/CD, task queues, and agent status in one view.
+- **Automated flow**: Create and update tickets directly from agent output.
+- **Better decisions**: Context and embeddings turn history into insight.
+
 ---
 
 ## System Overview

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -45,6 +45,7 @@ Core infrastructure for orchestrating Claude Code agents with data sovereignty.
 - [ ] Message type filtering (show only tool calls, errors, etc.)
 - [ ] Conversation replay viewer (step through history)
 - [ ] Agent comparison view (side-by-side outputs)
+- [ ] All-in-one ops view (Jira/Linear auto creation, CI/CD views, task scheduling/planning, context insights via vector embeddings)
 
 ---
 


### PR DESCRIPTION
## Summary
- add Bloomberg-style ops terminal principle in architecture
- add all-in-one ops view bullet to roadmap (Jira/Linear, CI/CD, scheduling, context embeddings)

## Testing
- not run (docs only)