### PR TITLE
chore: add auto-merge workflow for releases

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,19 @@
+name: auto-merge-release
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  auto-merge:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'autorelease: pending') }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Adds a GitHub Actions workflow to automatically merge Release Please PRs when they are labeled as pending.