### PR TITLE
fix(identity): inject git identity env vars correctly

### DIFF
--- a/internal/runner/claude.go
+++ b/internal/runner/claude.go
@@ -138,6 +138,15 @@ func buildClaudeOptions(spec RunSpec, resume bool) *claudecode.SpawnOptions {
 		Resume:         resume,
 	}
 
+	// Map git identity from runner spec to claudecode options
+	if spec.GitIdentity != nil {
+		opts.GitIdentity = &claudecode.GitIdentityConfig{
+			AuthorName:   spec.GitIdentity.AuthorName,
+			AuthorEmail:  spec.GitIdentity.AuthorEmail,
+			CoAuthorLine: spec.GitIdentity.CoAuthorLine,
+		}
+	}
+
 	if opts.PermissionMode == "" && spec.Plan {
 		opts.PermissionMode = "plan"
 	}


### PR DESCRIPTION
## Summary
- Fix git identity environment variables not being injected into agent processes
- Fix environment variable inheritance so agents don't lose PATH, HOME, etc.

## Changes
1. **internal/runner/claude.go**: Add mapping from `RunSpec.GitIdentity` to `claudecode.SpawnOptions.GitIdentity`
2. **pkg/claudecode/client.go**: Change `cmd.Env = append(cmd.Env, gitEnv...)` to `append(os.Environ(), gitEnv...)` to properly inherit parent environment

## Root Cause
Two bugs:
1. The runner wasn't passing git identity config to claudecode
2. When `cmd.Env` is nil, Go auto-inherits parent env. But `append(nil, ...)` creates a new slice with *only* the appended values, losing all other env vars.

## Test plan
- [x] Spawn executor agent with identity config
- [x] Verify commit shows bot identity as author
- [x] Verify ATHENA_CO_AUTHOR env var is set
- [x] Verify co-author trailer appears in commit message

🤖 Generated with [Claude Code](https://claude.ai/code)