### PR TITLE
feat(agent): auto-publish PRs when executor completes in automatic mode

### DIFF
--- a/internal/agent/spawner_test.go
+++ b/internal/agent/spawner_test.go
@@ -57,7 +57,7 @@ func TestSpawnerBuildRunSpec(t *testing.T) {
 	st, cfg, cleanup := setupTestEnv(t)
 	defer cleanup()
 
-	spawner := NewSpawner(cfg, st)
+	spawner := NewSpawner(cfg, st, nil) // nil publisher for tests
 
 	t.Run("PlannerArchetype", func(t *testing.T) {
 		spec := SpawnSpec{
@@ -132,7 +132,7 @@ func TestSpawnerListRunning(t *testing.T) {
 	st, cfg, cleanup := setupTestEnv(t)
 	defer cleanup()
 
-	spawner := NewSpawner(cfg, st)
+	spawner := NewSpawner(cfg, st, nil) // nil publisher for tests
 
 	// Initially no running processes
 	running := spawner.ListRunning()
@@ -206,7 +206,7 @@ func TestPipelineIntegration(t *testing.T) {
 	st, cfg, cleanup := setupTestEnv(t)
 	defer cleanup()
 
-	spawner := NewSpawner(cfg, st)
+	spawner := NewSpawner(cfg, st, nil) // nil publisher for tests
 
 	// Pipeline should be created
 	pipeline := spawner.Pipeline()

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -76,6 +76,8 @@ func New(cfg *config.Config) (*Daemon, error) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
+	publisher := worktree.NewPublisher(cfg, st)
+
 	d := &Daemon{
 		config:      cfg,
 		store:       st,
@@ -83,8 +85,8 @@ func New(cfg *config.Config) (*Daemon, error) {
 		scanner:     worktree.NewScanner(cfg, st),
 		provisioner: worktree.NewProvisioner(cfg, st),
 		migrator:    worktree.NewMigrator(cfg, st),
-		publisher:   worktree.NewPublisher(cfg, st),
-		spawner:     agent.NewSpawner(cfg, st),
+		publisher:   publisher,
+		spawner:     agent.NewSpawner(cfg, st, publisher),
 		agents:      make(map[string]*AgentProcess),
 		jobQueue:    make(chan string, 100),
 		ctx:         ctx,


### PR DESCRIPTION
## Summary
- Automatically publish PRs to GitHub when executor completes successfully in `automatic` workflow mode
- Extends existing auto-workflow pattern (planner → executor) with final step (executor → PR)
- Only triggers when: executor archetype, GitHub integration enabled, automatic workflow, no existing PR, clean working tree

## Implementation
- Add `publisher` field to Spawner struct
- Add `maybeAutoPublishPR()` method mirroring `maybeAutoSpawnExecutor()`
- Hook auto-publish into `handleExit()` on successful completion

🤖 Generated with [Claude Code](https://claude.ai/code)