### PR TITLE
feat(tui): polish admin view and add debug logging

### DIFF
--- a/cmd/athena/main.go
+++ b/cmd/athena/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/spf13/cobra"
 	"github.com/drewfead/athena/internal/config"
+	"github.com/spf13/cobra"
 )
 
 var cfg *config.Config
@@ -117,6 +117,10 @@ Examples:
 }
 
 func init() {
+	// TUI debug flags
+	rootCmd.PersistentFlags().BoolVar(&debugKeys, "debug-keys", false, "Log keystrokes for TUI debugging")
+	rootCmd.PersistentFlags().StringVar(&debugLogPath, "debug-log", "", "Write TUI debug logs to this file")
+
 	// Migration flags
 	migrateCmd.Flags().BoolP("execute", "e", false, "Execute the migration (default: show plan only)")
 

--- a/internal/tui/dashboard/view_admin.go
+++ b/internal/tui/dashboard/view_admin.go
@@ -6,73 +6,73 @@ import (
 	"strings"
 	"time"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/drewfead/athena/internal/control"
 	"github.com/drewfead/athena/internal/tui"
 	"github.com/drewfead/athena/internal/tui/layout"
 )
 
+type adminSummary struct {
+	totalAgents     int
+	activeAgents    int
+	runningAgents   int
+	planningAgents  int
+	executingAgents int
+	awaitingAgents  int
+	crashedAgents   int
+	totalTokens     int
+	totalCacheReads int
+	totalDuration   int64
+	totalToolCalls  int
+	totalFilesRead  int
+	totalFilesWrite int
+	totalLines      int
+	totalRestarts   int
+}
+
 func (m Model) renderAdmin() string {
 	var b strings.Builder
 
 	contentHeight := layout.ContentHeight(m.height)
+	summary := summarizeAdmin(m.agents)
+	summaryBlock := m.renderAdminSummary(summary)
+	summaryHeight := lipgloss.Height(summaryBlock)
 
-	// Summary Stats
-	totalAgents := len(m.agents)
-	activeAgents := 0
-	totalTokens := 0
-	totalCacheReads := 0
-	totalDuration := int64(0)
-
-	for _, a := range m.agents {
-		if a.Status == "running" || a.Status == "planning" || a.Status == "executing" {
-			activeAgents++
-		}
-		if a.Metrics != nil {
-			totalTokens += a.Metrics.TotalTokens
-			totalCacheReads += a.Metrics.CacheReads
-			totalDuration += a.Metrics.DurationMs
-		}
-	}
-
-	b.WriteString(tui.StyleAccent.Render("System Status"))
-	b.WriteString("\n")
-
-	stats := []string{
-		fmt.Sprintf("Agents: %d (%d active)", totalAgents, activeAgents),
-		fmt.Sprintf("Total Tokens: %s", formatCompactNumber(totalTokens)),
-		fmt.Sprintf("Cache Reads: %d", totalCacheReads),
-		fmt.Sprintf("Total Compute: %s", formatDurationMs(totalDuration)),
-	}
-	b.WriteString(strings.Join(stats, "  │  "))
+	b.WriteString(summaryBlock)
 	b.WriteString("\n\n")
 
-	b.WriteString(tui.StyleAccent.Render("Agent Performance & Context"))
+	b.WriteString(tui.StyleAccent.Render("Agent Activity"))
 	b.WriteString("\n")
 
-	// Agent Table
 	table := layout.NewTable([]layout.Column{
-		{Header: "AGENT", MinWidth: 15, MaxWidth: 20, Flex: 1},
-		{Header: "WORKTREE", MinWidth: 20, MaxWidth: 40, Flex: 2},
-		{Header: "TOKENS", MinWidth: 10, MaxWidth: 12, Flex: 0},
-		{Header: "CACHE", MinWidth: 8, MaxWidth: 10, Flex: 0},
-		{Header: "DUR", MinWidth: 8, MaxWidth: 10, Flex: 0},
-		{Header: "STATUS", MinWidth: 10, MaxWidth: 12, Flex: 0},
+		{Header: "AGENT", MinWidth: 8, MaxWidth: 10, Flex: 0},
+		{Header: "PROJECT", MinWidth: 10, MaxWidth: 16, Flex: 1},
+		{Header: "STATUS", MinWidth: 8, MaxWidth: 10, Flex: 0},
+		{Header: "ACTIVITY", MinWidth: 18, MaxWidth: 40, Flex: 2},
+		{Header: "WORKTREE", MinWidth: 14, MaxWidth: 28, Flex: 1},
+		{Header: "TOKENS", MinWidth: 8, MaxWidth: 10, Flex: 0},
+		{Header: "DUR", MinWidth: 6, MaxWidth: 8, Flex: 0},
+		{Header: "RST", MinWidth: 3, MaxWidth: 5, Flex: 0},
 	})
 	table.SetWidth(m.width)
+	table.SetVisibleColumns(adminVisibleColumns(m.width))
 
 	b.WriteString(table.RenderHeader())
 	b.WriteString("\n")
 
-	// Filter and sort agents (most recent first)
 	agents := make([]*control.AgentInfo, len(m.agents))
 	copy(agents, m.agents)
 	sort.Slice(agents, func(i, j int) bool {
-		return agents[i].CreatedAt > agents[j].CreatedAt // Descending
+		return adminSortTime(agents[i]).After(adminSortTime(agents[j]))
 	})
 
-	// Calculate scroll
-	// Subtract header(3) + summary(3) + footer(1)
-	availableRows := max(contentHeight-7, 1)
+	if len(agents) == 0 {
+		b.WriteString(tui.StyleEmptyState.Render("   No agents yet."))
+		return b.String()
+	}
+
+	overhead := summaryHeight + 3
+	availableRows := max(contentHeight-overhead, 1)
 
 	scroll := layout.CalculateScrollWindow(len(agents), m.selected, availableRows)
 
@@ -99,30 +99,221 @@ func (m Model) renderAdmin() string {
 	return b.String()
 }
 
-func (m Model) renderAdminAgentRow(agent *control.AgentInfo, table *layout.Table, selected bool) string {
-	tokens := "0"
-	cache := "0"
-	duration := "0s"
+func (m Model) renderAdminSummary(summary adminSummary) string {
+	gap := 2
+	cols := 3
+	cardWidth := (m.width - gap*(cols-1)) / cols
+	if cardWidth < 24 {
+		cols = 2
+		cardWidth = (m.width - gap) / 2
+	}
+	if cardWidth < 24 {
+		cols = 1
+		cardWidth = m.width
+	}
+	if cardWidth < 1 {
+		cardWidth = 1
+	}
 
+	updated := "n/a"
+	if !m.lastUpdate.IsZero() {
+		updated = fmt.Sprintf("%s ago", formatDuration(time.Since(m.lastUpdate)))
+	}
+
+	daemonStatus := tui.StyleDanger.Render("offline")
+	if m.client != nil && m.client.Connected() {
+		daemonStatus = tui.StyleSuccess.Render("online")
+	}
+
+	attention := summary.awaitingAgents + summary.crashedAgents
+	attentionStyle := tui.StyleMuted
+	if attention > 0 {
+		attentionStyle = tui.StyleWarning
+		if summary.crashedAgents > 0 {
+			attentionStyle = tui.StyleDanger
+		}
+	}
+
+	cards := []string{
+		adminCard("Health", []string{
+			adminMetricLine("daemon", daemonStatus),
+			adminMetricLine("workflow", m.renderWorkflowStatus()),
+			adminMetricLine("updated", updated),
+		}, cardWidth),
+		adminCard("Agents", []string{
+			adminMetricLine("active", tui.StyleAccent.Render(fmt.Sprintf("%d/%d", summary.activeAgents, summary.totalAgents))),
+			adminMetricLine("attention", attentionStyle.Render(fmt.Sprintf("%d", attention))),
+			adminMetricLine("restarts", fmt.Sprintf("%d", summary.totalRestarts)),
+		}, cardWidth),
+		adminCard("Usage", []string{
+			adminMetricLine("tokens", tui.StyleAccent.Render(formatCompactNumber(summary.totalTokens))),
+			adminMetricLine("cache", fmt.Sprintf("%d", summary.totalCacheReads)),
+			adminMetricLine("compute", formatDurationMs(summary.totalDuration)),
+		}, cardWidth),
+		adminCard("Ops", []string{
+			adminMetricLine("tools", fmt.Sprintf("%d", summary.totalToolCalls)),
+			adminMetricLine("files", fmt.Sprintf("%dR/%dW", summary.totalFilesRead, summary.totalFilesWrite)),
+			adminMetricLine("changes", fmt.Sprintf("%d", summary.totalLines)),
+		}, cardWidth),
+	}
+
+	var rows []string
+	for i := 0; i < len(cards); i += cols {
+		end := min(i+cols, len(cards))
+		rows = append(rows, joinCards(cards[i:end], gap))
+	}
+
+	return strings.Join(rows, "\n")
+}
+
+func (m Model) renderAdminAgentRow(agent *control.AgentInfo, table *layout.Table, selected bool) string {
+	tokens := tui.StyleMuted.Render("-")
+	duration := tui.StyleMuted.Render("-")
 	if agent.Metrics != nil {
 		tokens = formatCompactNumber(agent.Metrics.TotalTokens)
-		cache = fmt.Sprintf("%d", agent.Metrics.CacheReads)
 		duration = formatDurationMs(agent.Metrics.DurationMs)
 	}
 
-	statusStyle := tui.StatusStyle(agent.Status)
-	status := statusStyle.Render(agent.Status)
+	project := agent.ProjectName
+	if project == "" {
+		project = agent.Project
+	}
+	if project == "" {
+		project = "-"
+	}
+
+	activity := formatActivity(agent)
+	if activity == "" {
+		activity = "-"
+	}
+
+	worktree := truncatePath(agent.WorktreePath, 26)
+	if worktree == "" {
+		worktree = "-"
+	}
+
+	statusText := strings.ToUpper(agent.Status)
+	if statusText == "" {
+		statusText = "UNKNOWN"
+	}
+	status := tui.StatusStyle(agent.Status).Render(statusText)
+
+	restarts := fmt.Sprintf("%d", agent.RestartCount)
 
 	values := []string{
 		shortID(agent.ID, 8),
-		truncatePath(agent.WorktreePath, 30),
-		tokens,
-		cache,
-		duration,
+		project,
 		status,
+		activity,
+		worktree,
+		tokens,
+		duration,
+		restarts,
 	}
 
-	return table.RenderRow(values, selected)
+	return table.RenderRowStyled(values, selected)
+}
+
+func summarizeAdmin(agents []*control.AgentInfo) adminSummary {
+	summary := adminSummary{
+		totalAgents: len(agents),
+	}
+
+	for _, a := range agents {
+		switch a.Status {
+		case "running":
+			summary.runningAgents++
+			summary.activeAgents++
+		case "planning":
+			summary.planningAgents++
+			summary.activeAgents++
+		case "executing":
+			summary.executingAgents++
+			summary.activeAgents++
+		case "awaiting":
+			summary.awaitingAgents++
+		case "crashed":
+			summary.crashedAgents++
+		}
+
+		summary.totalRestarts += a.RestartCount
+
+		if a.Metrics != nil {
+			summary.totalTokens += a.Metrics.TotalTokens
+			summary.totalCacheReads += a.Metrics.CacheReads
+			summary.totalDuration += a.Metrics.DurationMs
+			summary.totalToolCalls += a.Metrics.ToolUseCount
+			summary.totalFilesRead += a.Metrics.FilesRead
+			summary.totalFilesWrite += a.Metrics.FilesWritten
+			summary.totalLines += a.Metrics.LinesChanged
+		}
+	}
+
+	return summary
+}
+
+func adminMetricLine(label, value string) string {
+	return fmt.Sprintf("%s %s", tui.StyleMuted.Render(label), value)
+}
+
+func adminCard(title string, lines []string, width int) string {
+	cardStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(tui.ColorAccentDim).
+		Padding(0, 1)
+
+	content := append([]string{tui.StyleHeader.Render(title)}, lines...)
+	return cardStyle.Width(width).Render(strings.Join(content, "\n"))
+}
+
+func joinCards(cards []string, gap int) string {
+	if len(cards) == 0 {
+		return ""
+	}
+	if len(cards) == 1 {
+		return cards[0]
+	}
+
+	spacer := lipgloss.NewStyle().Width(gap).Render("")
+	blocks := make([]string, 0, len(cards)*2-1)
+	for i, card := range cards {
+		if i > 0 {
+			blocks = append(blocks, spacer)
+		}
+		blocks = append(blocks, card)
+	}
+
+	return lipgloss.JoinHorizontal(lipgloss.Top, blocks...)
+}
+
+func adminVisibleColumns(width int) []bool {
+	if width < 85 {
+		return []bool{true, true, true, true, false, false, false, false}
+	}
+	if width < 100 {
+		return []bool{true, true, true, true, true, false, false, false}
+	}
+	if width < 115 {
+		return []bool{true, true, true, true, true, true, false, false}
+	}
+	if width < 130 {
+		return []bool{true, true, true, true, true, true, true, false}
+	}
+	return []bool{true, true, true, true, true, true, true, true}
+}
+
+func adminSortTime(agent *control.AgentInfo) time.Time {
+	if agent.LastActivityTime != "" {
+		if t := parseCreatedAt(agent.LastActivityTime); !t.IsZero() {
+			return t
+		}
+	}
+	if agent.CreatedAt != "" {
+		if t := parseCreatedAt(agent.CreatedAt); !t.IsZero() {
+			return t
+		}
+	}
+	return time.Time{}
 }
 
 func formatDurationMs(ms int64) string {

--- a/internal/tui/dashboard/view_project.go
+++ b/internal/tui/dashboard/view_project.go
@@ -100,101 +100,6 @@ func (m Model) renderAgentRow(agent *control.AgentInfo, table *layout.Table, sel
 	return table.RenderRow(values, selected)
 }
 
-// Fun status messages by agent state
-var funStatusMessages = map[string][]string{
-	"planning": {
-		"Brainstorming...",
-		"Calculating...",
-		"Wondering...",
-		"Pondering the orb...",
-		"Strategizing...",
-		"Connecting dots...",
-		"Reviewing the plan...",
-		"Consulting the oracle...",
-		"Simulating outcomes...",
-		"Thinking deeply...",
-		"Analyzing requirements...",
-		"Mapping the territory...",
-		"Sketching ideas...",
-		"Formulating hypothesis...",
-		"Checking the map...",
-		"Plotting course...",
-		"Synthesizing data...",
-		"Optimizing route...",
-		"Designing solution...",
-		"Architecting...",
-		"Dreaming up code...",
-		"Consulting rubber duck...",
-		"Parsing intent...",
-		"Decoding matrix...",
-		"Checking specifications...",
-	},
-	"executing": {
-		"Grafting...",
-		"Putting in the work...",
-		"Doing your work...",
-		"Writing code...",
-		"Crushing tickets...",
-		"Shipping features...",
-		"Generating value...",
-		"Refactoring reality...",
-		"Compiling success...",
-		"Executing order 66...",
-		"Applying fixes...",
-		"Hammering the keyboard...",
-		"Typing furiously...",
-		"Injecting logic...",
-		"Polishing pixels...",
-		"Wiring circuits...",
-		"Building the future...",
-		"Deploying brilliance...",
-		"Making it happen...",
-		"Crunching bits...",
-		"Assembling bytes...",
-		"Weaving software...",
-		"Crafting elegance...",
-		"Solving puzzles...",
-		"Getting it done...",
-	},
-	"running": {
-		"Working...",
-		"Busy...",
-		"On the job...",
-		"Processing...",
-		"Handling it...",
-		"In the zone...",
-		"Flow state...",
-		"Running cycles...",
-		"Spinning up...",
-		"Active...",
-	},
-}
-
-// getFunStatus returns a consistent random message based on agent ID and state.
-// We use the ID as a seed so the message doesn't flicker on every render frame.
-func getFunStatus(id, state string) string {
-	msgs, ok := funStatusMessages[state]
-	if !ok || len(msgs) == 0 {
-		return ""
-	}
-	
-	// Simple hash of ID to pick a message
-	hash := 0
-	for _, c := range id {
-		hash += int(c)
-	}
-	
-	// Add state length to vary it when state changes
-	hash += len(state)
-	
-	// Use time (minute) to rotate messages occasionally but not too fast
-	// This keeps it "alive" but readable
-	hash += time.Now().Minute()
-	
-	idx := hash % len(msgs)
-	return msgs[idx]
-}
-
 // formatActivity returns a human-readable description of what the agent is doing.
 // If LastActivity is populated, it shows that with a relative time suffix.
 // Otherwise, it falls back to descriptive status messages.
@@ -227,21 +132,23 @@ func formatActivity(agent *control.AgentInfo) string {
 		return agent.LastActivity
 	}
 
-	// Fallback to status-based descriptions with fun flavor
-	funMsg := getFunStatus(agent.ID, agent.Status)
-	if funMsg != "" {
-		return tui.StyleDanger.Render(funMsg) // "nice pink" as requested
-	}
-
 	switch agent.Status {
+	case "planning":
+		return tui.StyleInfo.Render("Planning")
+	case "executing":
+		return tui.StyleSuccess.Render("Executing")
+	case "running":
+		return tui.StyleSuccess.Render("Running")
 	case "awaiting":
-		return "Waiting for user input"
+		return tui.StyleWarning.Render("Awaiting input")
 	case "crashed":
-		return tui.StyleDanger.Render("Process crashed - needs restart")
-	case "stopped":
-		return "Stopped"
+		return tui.StyleDanger.Render("Crashed - needs restart")
+	case "pending":
+		return tui.StyleMuted.Render("Queued")
+	case "spawning":
+		return tui.StyleWarning.Render("Spawning")
 	case "completed":
-		return tui.StyleMuted.Render("—")
+		return tui.StyleMuted.Render("Complete")
 	default:
 		return agent.Status
 	}


### PR DESCRIPTION
## Summary
- redesign admin tab with summary cards and activity-focused table
- remove playful agent activity copy in favor of professional statuses
- add optional TUI keystroke logging with CLI flags
- guard narrow terminal widths in detail boxes and viewer

## Testing
- go test ./... (fails: go toolchain mismatch; stdlib 1.22.12 vs tool 1.25.6, and missing iter package)

## Notes
- Changelog entry: run `athena changelog add ...` once the daemon is running