### PR TITLE
feat: add CLI format flags and cache hit rate tracking

### DIFF
--- a/internal/agent/spawner.go
+++ b/internal/agent/spawner.go
@@ -41,11 +41,12 @@ type Spawner struct {
 
 // ManagedProcess wraps a Claude process with management metadata.
 type ManagedProcess struct {
-	AgentID   string
-	SessionID string
-	MetricsID string // ID of the agent_metrics record
-	Process   runner.Session
-	Cancel    context.CancelFunc
+	AgentID       string
+	SessionID     string
+	MetricsID     string // ID of the agent_metrics record
+	CacheMetricID string // ID of the context_cache_metrics record
+	Process       runner.Session
+	Cancel        context.CancelFunc
 }
 
 // NewSpawner creates a new agent spawner with default pipeline.
@@ -163,13 +164,20 @@ func (s *Spawner) Spawn(ctx context.Context, spec SpawnSpec) (*store.Agent, erro
 		metricsID = metrics.ID
 	}
 
+	// Record initial context cache metrics
+	var cacheMetricID string
+	if s.contextMgr != nil {
+		cacheMetricID = s.recordInitialContextStats(agentID, spec.WorktreePath, spec.ProjectName)
+	}
+
 	// Track the managed process
 	mp := &ManagedProcess{
-		AgentID:   agentID,
-		SessionID: sessionID,
-		MetricsID: metricsID,
-		Process:   session,
-		Cancel:    cancel,
+		AgentID:       agentID,
+		SessionID:     sessionID,
+		MetricsID:     metricsID,
+		CacheMetricID: cacheMetricID,
+		Process:       session,
+		Cancel:        cancel,
 	}
 
 	s.mu.Lock()
@@ -460,6 +468,11 @@ func (s *Spawner) processEvent(mp *ManagedProcess, event runner.Event) {
 					"cache_reads", event.Usage.CacheReads,
 					"cost_usd", event.CostUSD,
 				)
+			}
+
+			// Update context cache metrics with cache read data
+			if event.Usage.CacheReads > 0 {
+				s.updateCacheMetrics(mp, event.Usage.CacheReads)
 			}
 		}
 	}
@@ -838,4 +851,115 @@ func isToolResultError(content string) bool {
 		}
 	}
 	return false
+}
+
+// recordInitialContextStats records context statistics at agent spawn time.
+// Returns the cache metric ID for later updates.
+func (s *Spawner) recordInitialContextStats(agentID, worktreePath, projectName string) string {
+	if s.contextMgr == nil {
+		return ""
+	}
+
+	// Get context stats
+	stats, err := s.contextMgr.GetContextStats(worktreePath, projectName)
+	if err != nil {
+		logging.Warn("failed to get context stats", "agent_id", agentID, "error", err)
+		return ""
+	}
+
+	// Check if this is the first agent on the project
+	isFirst, err := s.store.IsFirstAgentOnProject(projectName)
+	if err != nil {
+		logging.Warn("failed to check first agent status", "project", projectName, "error", err)
+		isFirst = true // Assume first if we can't check
+	}
+
+	// Create cache metric record
+	metric := &store.ContextCacheMetric{
+		AgentID:                  agentID,
+		ProjectName:              projectName,
+		WorktreePath:             worktreePath,
+		StateEntriesCount:        stats.StateEntriesCount,
+		StateTokensEstimate:      stats.StateTokensEstimate,
+		BlackboardEntriesCount:   stats.BlackboardEntriesCount,
+		BlackboardTokensEstimate: stats.BlackboardTokensEstimate,
+		TotalContextTokens:       stats.TotalContextTokens,
+		IsFirstAgent:             isFirst,
+	}
+
+	if err := s.store.CreateContextCacheMetric(metric); err != nil {
+		logging.Warn("failed to create context cache metric", "agent_id", agentID, "error", err)
+		return ""
+	}
+
+	logging.Debug("recorded initial context stats",
+		"agent_id", agentID,
+		"project", projectName,
+		"state_entries", stats.StateEntriesCount,
+		"state_tokens", stats.StateTokensEstimate,
+		"blackboard_entries", stats.BlackboardEntriesCount,
+		"blackboard_tokens", stats.BlackboardTokensEstimate,
+		"is_first_agent", isFirst,
+	)
+
+	return metric.ID
+}
+
+// updateCacheMetrics updates the cache metrics with actual cache read data from the result event.
+// Uses a heuristic to attribute cache reads to state vs blackboard sections.
+func (s *Spawner) updateCacheMetrics(mp *ManagedProcess, cacheReads int) {
+	if mp.CacheMetricID == "" {
+		return
+	}
+
+	// Get the existing metric to access token estimates
+	metric, err := s.store.GetContextCacheMetricForAgent(mp.AgentID)
+	if err != nil || metric == nil {
+		logging.Warn("failed to get cache metric for update", "agent_id", mp.AgentID, "error", err)
+		return
+	}
+
+	// Attribute cache reads to sections using prefix heuristic:
+	// State section is first in the context (STABLE section), so cache reads up to
+	// state token count are attributed to state.
+	cacheReadsInState := cacheReads
+	cacheReadsInBlackboard := 0
+
+	if cacheReads > metric.StateTokensEstimate {
+		// Some cache reads go to state, remainder to blackboard
+		cacheReadsInState = metric.StateTokensEstimate
+		cacheReadsInBlackboard = cacheReads - metric.StateTokensEstimate
+		if cacheReadsInBlackboard > metric.BlackboardTokensEstimate {
+			// Cap at blackboard estimate
+			cacheReadsInBlackboard = metric.BlackboardTokensEstimate
+		}
+	}
+
+	// Calculate cache hit rate
+	var cacheHitRate float64
+	if metric.TotalContextTokens > 0 {
+		cacheHitRate = float64(cacheReads) / float64(metric.TotalContextTokens) * 100
+		if cacheHitRate > 100 {
+			cacheHitRate = 100 // Cap at 100%
+		}
+	}
+
+	// Update the metric
+	metric.CacheReadsTotal = cacheReads
+	metric.CacheReadsInState = cacheReadsInState
+	metric.CacheReadsInBlackboard = cacheReadsInBlackboard
+	metric.CacheHitRate = cacheHitRate
+
+	if err := s.store.UpdateContextCacheMetric(metric); err != nil {
+		logging.Warn("failed to update cache metric", "agent_id", mp.AgentID, "error", err)
+		return
+	}
+
+	logging.Info("updated context cache metrics",
+		"agent_id", mp.AgentID,
+		"cache_reads_total", cacheReads,
+		"cache_reads_in_state", cacheReadsInState,
+		"cache_reads_in_blackboard", cacheReadsInBlackboard,
+		"cache_hit_rate", cacheHitRate,
+	)
 }

--- a/internal/context/types.go
+++ b/internal/context/types.go
@@ -117,3 +117,18 @@ type StateSummary struct {
 	TotalCount        int
 	AvgConfidence     float64
 }
+
+// ContextStats provides statistics about the context that would be provided to an agent.
+// This is used for cache hit rate tracking and analysis.
+type ContextStats struct {
+	// State section (STABLE - cached across agents on same project)
+	StateEntriesCount   int
+	StateTokensEstimate int
+
+	// Blackboard section (SEMI-STABLE - cached within workflow)
+	BlackboardEntriesCount   int
+	BlackboardTokensEstimate int
+
+	// Total context
+	TotalContextTokens int
+}

--- a/internal/control/client.go
+++ b/internal/control/client.go
@@ -689,6 +689,22 @@ func (c *Client) GetContextPreview(worktreePath, projectName string) (string, er
 	return result.Context, nil
 }
 
+// GetCacheStats retrieves cross-agent cache hit rate statistics for a project.
+func (c *Client) GetCacheStats(projectName string) (*ProjectCacheStatsInfo, error) {
+	resp, err := c.Call("get_cache_stats", map[string]string{"project_name": projectName})
+	if err != nil {
+		return nil, err
+	}
+	if resp.Error != "" {
+		return nil, errors.New(resp.Error)
+	}
+
+	var stats ProjectCacheStatsInfo
+	data, _ := json.Marshal(resp.Data)
+	json.Unmarshal(data, &stats)
+	return &stats, nil
+}
+
 func (c *Client) readLoop() {
 	for c.scanner.Scan() {
 		select {
@@ -1049,6 +1065,20 @@ type StateSummaryInfo struct {
 	EnvironmentCount  int     `json:"environment_count"`
 	TotalCount        int     `json:"total_count"`
 	AvgConfidence     float64 `json:"avg_confidence"`
+}
+
+// ProjectCacheStatsInfo provides aggregated cache hit rate statistics for a project.
+type ProjectCacheStatsInfo struct {
+	ProjectName                 string  `json:"project_name"`
+	TotalAgents                 int     `json:"total_agents"`
+	FirstAgentCount             int     `json:"first_agent_count"`
+	SubsequentAgentCount        int     `json:"subsequent_agent_count"`
+	AvgCacheHitRate             float64 `json:"avg_cache_hit_rate"`
+	AvgFirstAgentCacheRate      float64 `json:"avg_first_agent_cache_rate"`
+	AvgSubsequentAgentCacheRate float64 `json:"avg_subsequent_agent_cache_rate"`
+	TotalStateTokens            int     `json:"total_state_tokens"`
+	TotalBlackboardTokens       int     `json:"total_blackboard_tokens"`
+	TotalCacheReads             int     `json:"total_cache_reads"`
 }
 
 // PostBlackboardRequest is the request to post a blackboard entry.

--- a/internal/store/cache_metrics.go
+++ b/internal/store/cache_metrics.go
@@ -1,0 +1,193 @@
+package store
+
+import (
+	"database/sql"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// CreateContextCacheMetric creates a new context cache metric record.
+func (s *Store) CreateContextCacheMetric(m *ContextCacheMetric) error {
+	if m.ID == "" {
+		m.ID = uuid.NewString()
+	}
+	if m.CreatedAt.IsZero() {
+		m.CreatedAt = time.Now()
+	}
+
+	_, err := s.db.Exec(`
+		INSERT INTO context_cache_metrics (
+			id, agent_id, project_name, worktree_path,
+			state_entries_count, state_tokens_estimate,
+			blackboard_entries_count, blackboard_tokens_estimate,
+			cache_reads_total, cache_reads_in_state, cache_reads_in_blackboard,
+			total_context_tokens, cache_hit_rate, is_first_agent, created_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		m.ID, m.AgentID, m.ProjectName, m.WorktreePath,
+		m.StateEntriesCount, m.StateTokensEstimate,
+		m.BlackboardEntriesCount, m.BlackboardTokensEstimate,
+		m.CacheReadsTotal, m.CacheReadsInState, m.CacheReadsInBlackboard,
+		m.TotalContextTokens, m.CacheHitRate, m.IsFirstAgent, m.CreatedAt,
+	)
+	return err
+}
+
+// UpdateContextCacheMetric updates an existing context cache metric record.
+func (s *Store) UpdateContextCacheMetric(m *ContextCacheMetric) error {
+	_, err := s.db.Exec(`
+		UPDATE context_cache_metrics SET
+			cache_reads_total = ?,
+			cache_reads_in_state = ?,
+			cache_reads_in_blackboard = ?,
+			cache_hit_rate = ?
+		WHERE id = ?
+	`,
+		m.CacheReadsTotal, m.CacheReadsInState, m.CacheReadsInBlackboard,
+		m.CacheHitRate, m.ID,
+	)
+	return err
+}
+
+// GetContextCacheMetricForAgent retrieves the cache metric for a specific agent.
+func (s *Store) GetContextCacheMetricForAgent(agentID string) (*ContextCacheMetric, error) {
+	m := &ContextCacheMetric{}
+	var worktreePath sql.NullString
+
+	err := s.db.QueryRow(`
+		SELECT id, agent_id, project_name, worktree_path,
+			state_entries_count, state_tokens_estimate,
+			blackboard_entries_count, blackboard_tokens_estimate,
+			cache_reads_total, cache_reads_in_state, cache_reads_in_blackboard,
+			total_context_tokens, cache_hit_rate, is_first_agent, created_at
+		FROM context_cache_metrics
+		WHERE agent_id = ?
+		ORDER BY created_at DESC LIMIT 1
+	`, agentID).Scan(
+		&m.ID, &m.AgentID, &m.ProjectName, &worktreePath,
+		&m.StateEntriesCount, &m.StateTokensEstimate,
+		&m.BlackboardEntriesCount, &m.BlackboardTokensEstimate,
+		&m.CacheReadsTotal, &m.CacheReadsInState, &m.CacheReadsInBlackboard,
+		&m.TotalContextTokens, &m.CacheHitRate, &m.IsFirstAgent, &m.CreatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if worktreePath.Valid {
+		m.WorktreePath = worktreePath.String
+	}
+
+	return m, nil
+}
+
+// GetProjectCacheStats retrieves aggregated cache statistics for a project.
+func (s *Store) GetProjectCacheStats(projectName string) (*ProjectCacheStats, error) {
+	stats := &ProjectCacheStats{ProjectName: projectName}
+
+	// Get counts and averages
+	err := s.db.QueryRow(`
+		SELECT
+			COUNT(*) as total_agents,
+			SUM(CASE WHEN is_first_agent THEN 1 ELSE 0 END) as first_agent_count,
+			SUM(CASE WHEN NOT is_first_agent THEN 1 ELSE 0 END) as subsequent_agent_count,
+			COALESCE(AVG(cache_hit_rate), 0) as avg_cache_hit_rate,
+			COALESCE(SUM(state_tokens_estimate), 0) as total_state_tokens,
+			COALESCE(SUM(blackboard_tokens_estimate), 0) as total_blackboard_tokens,
+			COALESCE(SUM(cache_reads_total), 0) as total_cache_reads
+		FROM context_cache_metrics
+		WHERE project_name = ?
+	`, projectName).Scan(
+		&stats.TotalAgents,
+		&stats.FirstAgentCount,
+		&stats.SubsequentAgentCount,
+		&stats.AvgCacheHitRate,
+		&stats.TotalStateTokens,
+		&stats.TotalBlackboardTokens,
+		&stats.TotalCacheReads,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get average cache rate for first agents
+	s.db.QueryRow(`
+		SELECT COALESCE(AVG(cache_hit_rate), 0)
+		FROM context_cache_metrics
+		WHERE project_name = ? AND is_first_agent = TRUE
+	`, projectName).Scan(&stats.AvgFirstAgentCacheRate)
+
+	// Get average cache rate for subsequent agents
+	s.db.QueryRow(`
+		SELECT COALESCE(AVG(cache_hit_rate), 0)
+		FROM context_cache_metrics
+		WHERE project_name = ? AND is_first_agent = FALSE
+	`, projectName).Scan(&stats.AvgSubsequentAgentCacheRate)
+
+	return stats, nil
+}
+
+// IsFirstAgentOnProject checks if there are any previous agents recorded for a project.
+// Returns true if no agents have been recorded yet (meaning the next agent would be the first).
+func (s *Store) IsFirstAgentOnProject(projectName string) (bool, error) {
+	var count int
+	err := s.db.QueryRow(`
+		SELECT COUNT(*) FROM context_cache_metrics WHERE project_name = ?
+	`, projectName).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+	return count == 0, nil
+}
+
+// ListProjectCacheMetrics retrieves all cache metrics for a project, ordered by creation time.
+func (s *Store) ListProjectCacheMetrics(projectName string, limit int) ([]ContextCacheMetric, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+
+	rows, err := s.db.Query(`
+		SELECT id, agent_id, project_name, worktree_path,
+			state_entries_count, state_tokens_estimate,
+			blackboard_entries_count, blackboard_tokens_estimate,
+			cache_reads_total, cache_reads_in_state, cache_reads_in_blackboard,
+			total_context_tokens, cache_hit_rate, is_first_agent, created_at
+		FROM context_cache_metrics
+		WHERE project_name = ?
+		ORDER BY created_at DESC
+		LIMIT ?
+	`, projectName, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var metrics []ContextCacheMetric
+	for rows.Next() {
+		var m ContextCacheMetric
+		var worktreePath sql.NullString
+
+		err := rows.Scan(
+			&m.ID, &m.AgentID, &m.ProjectName, &worktreePath,
+			&m.StateEntriesCount, &m.StateTokensEstimate,
+			&m.BlackboardEntriesCount, &m.BlackboardTokensEstimate,
+			&m.CacheReadsTotal, &m.CacheReadsInState, &m.CacheReadsInBlackboard,
+			&m.TotalContextTokens, &m.CacheHitRate, &m.IsFirstAgent, &m.CreatedAt,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		if worktreePath.Valid {
+			m.WorktreePath = worktreePath.String
+		}
+
+		metrics = append(metrics, m)
+	}
+
+	return metrics, rows.Err()
+}


### PR DESCRIPTION
## Summary

Two enhancements to the context optimization system:

### CLI Index Format Flags
- Add `--format` flag to `index query`, `index deps`, `index relevant` commands
- Supported formats: `text` (default), `json`, `compact`
- Add `--exported-only` flag to filter to public symbols
- JSON output is jq-parseable, compact is greppable

**Examples:**
```bash
athena index query SpawnAgent --format json
# [{"name":"SpawnAgent","kind":"func","file":"internal/agent/spawner.go","line":45}]

athena index deps daemon.go --format compact
# internal/daemon/daemon.go -> internal/agent

athena index relevant "fix auth" --json
```

### Cache Hit Rate Tracking
- New `context_cache_metrics` table tracking per-agent cache performance
- Record context structure (state/blackboard token estimates) at spawn
- Attribute cache hits to sections using prefix heuristic
- Track first agent vs subsequent agents for cache efficiency analysis

**New API endpoint:** `get_cache_stats` returns aggregated project stats including:
- Total agents, avg cache hit rate
- State vs blackboard cache efficiency
- First agent vs subsequent agent comparison

## Test plan
- [x] Build passes
- [x] All tests pass
- [ ] Manual testing of CLI format flags
- [ ] Manual testing with real agent runs to validate cache tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)