### PR TITLE
feat(queue): retain queue position and model divergence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ build:
 	go build $(LDFLAGS) -o bin/athena ./cmd/athena
 	go build $(LDFLAGS) -o bin/athenad ./cmd/athenad
 	go build $(LDFLAGS) -o bin/ath ./cmd/ath
-	go build $(LDFLAGS) -o bin/wt ./cmd/wt
 	go build $(LDFLAGS) -o bin/athena-cli ./cmd/athena-cli
 
 # Install all binaries to GOBIN
@@ -30,9 +29,8 @@ install: build
 	cp bin/athena $(GOBIN)/athena
 	cp bin/athenad $(GOBIN)/athenad
 	cp bin/ath $(GOBIN)/ath
-	cp bin/wt $(GOBIN)/wt
 	cp bin/athena-cli $(GOBIN)/athena-cli
-	@echo "Installed: athena, athenad, ath, wt, athena-cli"
+	@echo "Installed: athena, athenad, ath, cli"
 
 clean:
 	rm -rf bin/
@@ -127,7 +125,6 @@ help:
 	@echo "  athena   - TUI dashboard for monitoring agents"
 	@echo "  athenad  - Background daemon managing agent lifecycles"
 	@echo "  ath      - Quick CLI for work items (goals/features/tasks)"
-	@echo "  wt       - Standalone worktree management tool"
 	@echo ""
 	@echo "Usage:"
 	@echo "  make build     Build all binaries"

--- a/internal/daemon/merge_queue.go
+++ b/internal/daemon/merge_queue.go
@@ -28,6 +28,9 @@ func (d *Daemon) handleGetMergeQueue(params json.RawMessage) (any, error) {
 	if err := json.Unmarshal(params, &req); err != nil {
 		return nil, err
 	}
+	if err := d.refreshQueueGraph(req.Project); err != nil {
+		return nil, err
+	}
 
 	items, err := d.store.GetMergeQueue(req.Project)
 	if err != nil {
@@ -50,7 +53,7 @@ func (d *Daemon) handleGetMergeQueueHead(params json.RawMessage) (any, error) {
 		return nil, err
 	}
 
-	branch, commit, err := d.store.GetQueueHead(req.Project)
+	branch, commit, err := d.getIntegrationHead(req.Project)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +191,7 @@ func (d *Daemon) handleBumpMergeQueueItem(params json.RawMessage) (any, error) {
 		return nil, err
 	}
 
-	// Auto-rebase dependent features that were marked as 'rebasing'
+	// Auto-rebase dependent features that were marked as diverged/rebasing.
 	rebaseResults := d.cascadeRebase(originalItem.Project)
 
 	// Get updated item
@@ -210,7 +213,7 @@ func (d *Daemon) handleBumpMergeQueueItem(params json.RawMessage) (any, error) {
 	return mergeQueueItemToInfo(item), nil
 }
 
-// cascadeRebase automatically rebases all items marked as 'rebasing' in the queue.
+// cascadeRebase automatically rebases items marked as rebasing/diverged in the queue.
 // Returns a summary of rebase results.
 func (d *Daemon) cascadeRebase(project string) []map[string]string {
 	var results []map[string]string
@@ -272,6 +275,69 @@ func (d *Daemon) cascadeRebase(project string) []map[string]string {
 	}
 
 	return results
+}
+
+// getIntegrationHead returns the current integration base for spawning new worktrees.
+func (d *Daemon) getIntegrationHead(project string) (string, string, error) {
+	if err := d.refreshQueueGraph(project); err != nil {
+		return "", "", err
+	}
+	return d.store.GetQueueHead(project)
+}
+
+// refreshQueueGraph updates queue head commits from git and marks downstream divergence.
+func (d *Daemon) refreshQueueGraph(project string) error {
+	items, err := d.store.GetMergeQueue(project)
+	if err != nil {
+		return err
+	}
+	if len(items) == 0 {
+		return nil
+	}
+
+	// First pass: refresh each node's current HEAD commit.
+	for _, item := range items {
+		currentHead, err := getGitHead(item.WorktreePath)
+		if err != nil {
+			continue
+		}
+		if currentHead == item.HeadCommit {
+			continue
+		}
+		if err := d.store.UpdateMergeQueueItem(item.WorktreePath, item.Status, currentHead); err != nil {
+			return err
+		}
+		item.HeadCommit = currentHead
+	}
+
+	// Head of queue is always the root of the integration chain.
+	if items[0].Status == store.MergeQueueStatusDiverged {
+		if err := d.store.UpdateMergeQueueItem(items[0].WorktreePath, store.MergeQueueStatusQueued, items[0].HeadCommit); err != nil {
+			return err
+		}
+		items[0].Status = store.MergeQueueStatusQueued
+	}
+
+	stableHead := items[0].HeadCommit
+	for i := 1; i < len(items); i++ {
+		item := items[i]
+
+		// If base commit no longer matches upstream HEAD, this and descendants diverged.
+		if stableHead != "" && item.BaseCommit != stableHead {
+			return d.store.MarkQueueItemsDiverged(project, item.Position)
+		}
+
+		// If this item was previously diverged and now lines up, clear it.
+		if item.Status == store.MergeQueueStatusDiverged {
+			if err := d.store.UpdateMergeQueueItem(item.WorktreePath, store.MergeQueueStatusQueued, item.HeadCommit); err != nil {
+				return err
+			}
+		}
+
+		stableHead = item.HeadCommit
+	}
+
+	return nil
 }
 
 func (d *Daemon) handleRebaseMergeQueueItem(params json.RawMessage) (any, error) {

--- a/internal/store/merge_queue.go
+++ b/internal/store/merge_queue.go
@@ -11,11 +11,12 @@ import (
 type MergeQueueStatus string
 
 const (
-	MergeQueueStatusQueued    MergeQueueStatus = "queued"    // Waiting in line
-	MergeQueueStatusMerging   MergeQueueStatus = "merging"   // Currently being merged to main
-	MergeQueueStatusMerged    MergeQueueStatus = "merged"    // Successfully merged
-	MergeQueueStatusConflict  MergeQueueStatus = "conflict"  // Needs manual resolution
-	MergeQueueStatusRebasing  MergeQueueStatus = "rebasing"  // Being rebased after edit
+	MergeQueueStatusQueued   MergeQueueStatus = "queued"   // Waiting in line
+	MergeQueueStatusMerging  MergeQueueStatus = "merging"  // Currently being merged to main
+	MergeQueueStatusMerged   MergeQueueStatus = "merged"   // Successfully merged
+	MergeQueueStatusConflict MergeQueueStatus = "conflict" // Needs manual resolution
+	MergeQueueStatusRebasing MergeQueueStatus = "rebasing" // Being rebased after edit
+	MergeQueueStatusDiverged MergeQueueStatus = "diverged" // Upstream changed; needs reconciliation
 )
 
 // MergeQueueItem represents a worktree in the merge queue.
@@ -66,7 +67,7 @@ func (s *Store) AddToMergeQueue(item *MergeQueueItem) error {
 	var maxPos sql.NullInt64
 	err := s.db.QueryRow(`
 		SELECT MAX(position) FROM merge_queue
-		WHERE project = ? AND status IN ('queued', 'rebasing')
+		WHERE project = ? AND status IN ('queued', 'rebasing', 'diverged', 'conflict')
 	`, item.Project).Scan(&maxPos)
 	if err != nil {
 		return fmt.Errorf("failed to get max position: %w", err)
@@ -96,7 +97,7 @@ func (s *Store) GetMergeQueue(project string) ([]*MergeQueueItem, error) {
 	rows, err := s.db.Query(`
 		SELECT id, project, worktree_path, branch, position, status, base_branch, base_commit, head_commit, created_at, updated_at
 		FROM merge_queue
-		WHERE project = ? AND status IN ('queued', 'rebasing', 'merging')
+		WHERE project = ? AND status IN ('queued', 'rebasing', 'merging', 'diverged', 'conflict')
 		ORDER BY position ASC
 	`, project)
 	if err != nil {
@@ -150,29 +151,40 @@ func (s *Store) GetMergeQueueItem(worktreePath string) (*MergeQueueItem, error) 
 }
 
 // GetQueueHead returns the integration HEAD - the branch/commit that new worktrees should base on.
-// This is either the last queued item's branch, or the project's main branch if queue is empty.
+// It walks the queue from the front and returns the last non-diverged item.
 func (s *Store) GetQueueHead(project string) (branch string, commit string, err error) {
-	var baseBranch, baseCommit sql.NullString
-	err = s.db.QueryRow(`
-		SELECT branch, head_commit FROM merge_queue
-		WHERE project = ? AND status IN ('queued', 'rebasing')
-		ORDER BY position DESC
-		LIMIT 1
-	`, project).Scan(&baseBranch, &baseCommit)
-
-	if err == sql.ErrNoRows {
-		// Empty queue - return empty to signal "use main"
-		return "", "", nil
-	}
+	rows, err := s.db.Query(`
+		SELECT branch, head_commit, status
+		FROM merge_queue
+		WHERE project = ? AND status IN ('queued', 'rebasing', 'merging', 'diverged', 'conflict')
+		ORDER BY position ASC
+	`, project)
 	if err != nil {
 		return "", "", err
 	}
+	defer rows.Close()
 
-	if baseBranch.Valid {
-		branch = baseBranch.String
+	for rows.Next() {
+		var itemBranch sql.NullString
+		var headCommit sql.NullString
+		var status MergeQueueStatus
+		if err := rows.Scan(&itemBranch, &headCommit, &status); err != nil {
+			return "", "", err
+		}
+
+		// Divergence means the chain beyond this point is no longer a valid integration base.
+		if status == MergeQueueStatusDiverged || status == MergeQueueStatusConflict {
+			break
+		}
+		if itemBranch.Valid {
+			branch = itemBranch.String
+		}
+		if headCommit.Valid {
+			commit = headCommit.String
+		}
 	}
-	if baseCommit.Valid {
-		commit = baseCommit.String
+	if err := rows.Err(); err != nil {
+		return "", "", err
 	}
 	return branch, commit, nil
 }
@@ -222,8 +234,8 @@ func (s *Store) RemoveFromMergeQueue(worktreePath string) error {
 	return err
 }
 
-// MoveToBackOfQueue moves a worktree to the back of the queue (for when it's edited).
-// This also marks items after the original position as needing rebase.
+// MoveToBackOfQueue records an edited queue item without changing its position.
+// Items behind it are marked as diverged so they can be reconciled.
 func (s *Store) MoveToBackOfQueue(worktreePath string, newBaseCommit string) error {
 	item, err := s.GetMergeQueueItem(worktreePath)
 	if err != nil {
@@ -235,36 +247,20 @@ func (s *Store) MoveToBackOfQueue(worktreePath string, newBaseCommit string) err
 
 	originalPosition := item.Position
 
-	// Get max position
-	var maxPos sql.NullInt64
-	err = s.db.QueryRow(`
-		SELECT MAX(position) FROM merge_queue
-		WHERE project = ? AND status IN ('queued', 'rebasing')
-	`, item.Project).Scan(&maxPos)
-	if err != nil {
-		return err
-	}
-
-	newPos := 1
-	if maxPos.Valid {
-		newPos = int(maxPos.Int64)
-	}
-
-	// Move this item to the back
+	// Keep this item in-place and update its latest head commit.
 	_, err = s.db.Exec(`
 		UPDATE merge_queue
-		SET position = ?, base_commit = ?, status = 'queued', updated_at = CURRENT_TIMESTAMP
+		SET head_commit = ?, status = 'queued', updated_at = CURRENT_TIMESTAMP
 		WHERE worktree_path = ?
-	`, newPos, newBaseCommit, worktreePath)
+	`, newBaseCommit, worktreePath)
 	if err != nil {
 		return err
 	}
 
-	// Decrement positions for items that were after the original position
-	// and mark them as needing rebase
+	// Downstream items no longer cleanly stack and must be reconciled.
 	_, err = s.db.Exec(`
 		UPDATE merge_queue
-		SET position = position - 1, status = 'rebasing', updated_at = CURRENT_TIMESTAMP
+		SET status = 'diverged', updated_at = CURRENT_TIMESTAMP
 		WHERE project = ? AND position > ? AND worktree_path != ?
 	`, item.Project, originalPosition, worktreePath)
 	return err
@@ -275,7 +271,7 @@ func (s *Store) GetItemsNeedingRebase(project string) ([]*MergeQueueItem, error)
 	rows, err := s.db.Query(`
 		SELECT id, project, worktree_path, branch, position, status, base_branch, base_commit, head_commit, created_at, updated_at
 		FROM merge_queue
-		WHERE project = ? AND status = 'rebasing'
+		WHERE project = ? AND status IN ('rebasing', 'diverged')
 		ORDER BY position ASC
 	`, project)
 	if err != nil {
@@ -313,11 +309,21 @@ func (s *Store) MarkQueueItemRebased(worktreePath string, newBaseCommit, newHead
 	return err
 }
 
+// MarkQueueItemsDiverged marks queue items at or after a position as diverged.
+func (s *Store) MarkQueueItemsDiverged(project string, startPosition int) error {
+	_, err := s.db.Exec(`
+		UPDATE merge_queue
+		SET status = 'diverged', updated_at = CURRENT_TIMESTAMP
+		WHERE project = ? AND position >= ? AND status IN ('queued', 'rebasing', 'diverged')
+	`, project, startPosition)
+	return err
+}
+
 // GetActiveQueueProjects returns a list of projects that have items in the merge queue.
 func (s *Store) GetActiveQueueProjects() ([]string, error) {
 	rows, err := s.db.Query(`
 		SELECT DISTINCT project FROM merge_queue
-		WHERE status IN ('queued', 'rebasing', 'merging')
+		WHERE status IN ('queued', 'rebasing', 'merging', 'diverged', 'conflict')
 	`)
 	if err != nil {
 		return nil, err

--- a/internal/store/merge_queue_test.go
+++ b/internal/store/merge_queue_test.go
@@ -1,0 +1,164 @@
+package store
+
+import "testing"
+
+func TestMoveToBackOfQueueKeepsPositionAndMarksDiverged(t *testing.T) {
+	st, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	project := "proj"
+	paths := []string{
+		"/tmp/proj-a",
+		"/tmp/proj-b",
+		"/tmp/proj-c",
+	}
+	branches := []string{"feat/a", "feat/b", "feat/c"}
+
+	for i := range paths {
+		if err := st.UpsertWorktree(&Worktree{
+			Path:    paths[i],
+			Project: project,
+			Branch:  branches[i],
+			IsMain:  false,
+			Status:  WorktreeStatusActive,
+		}); err != nil {
+			t.Fatalf("failed to seed worktree %d: %v", i, err)
+		}
+	}
+
+	seed := []*MergeQueueItem{
+		{
+			ID:           "qa",
+			Project:      project,
+			WorktreePath: paths[0],
+			Branch:       branches[0],
+			BaseBranch:   "main",
+			BaseCommit:   "main0",
+			HeadCommit:   "a1",
+		},
+		{
+			ID:           "qb",
+			Project:      project,
+			WorktreePath: paths[1],
+			Branch:       branches[1],
+			BaseBranch:   branches[0],
+			BaseCommit:   "a1",
+			HeadCommit:   "b1",
+		},
+		{
+			ID:           "qc",
+			Project:      project,
+			WorktreePath: paths[2],
+			Branch:       branches[2],
+			BaseBranch:   branches[1],
+			BaseCommit:   "b1",
+			HeadCommit:   "c1",
+		},
+	}
+	for _, item := range seed {
+		if err := st.AddToMergeQueue(item); err != nil {
+			t.Fatalf("failed to add queue item %s: %v", item.ID, err)
+		}
+	}
+
+	if err := st.MoveToBackOfQueue(paths[0], "a2"); err != nil {
+		t.Fatalf("MoveToBackOfQueue failed: %v", err)
+	}
+
+	items, err := st.GetMergeQueue(project)
+	if err != nil {
+		t.Fatalf("GetMergeQueue failed: %v", err)
+	}
+	if len(items) != 3 {
+		t.Fatalf("expected 3 queue items, got %d", len(items))
+	}
+
+	if items[0].Position != 1 || items[0].WorktreePath != paths[0] {
+		t.Fatalf("first item moved unexpectedly: pos=%d path=%s", items[0].Position, items[0].WorktreePath)
+	}
+	if items[0].HeadCommit != "a2" {
+		t.Fatalf("expected updated head commit a2, got %s", items[0].HeadCommit)
+	}
+	if items[0].Status != MergeQueueStatusQueued {
+		t.Fatalf("expected first item queued, got %s", items[0].Status)
+	}
+
+	if items[1].Position != 2 || items[1].Status != MergeQueueStatusDiverged {
+		t.Fatalf("expected second item diverged at pos2, got status=%s pos=%d", items[1].Status, items[1].Position)
+	}
+	if items[2].Position != 3 || items[2].Status != MergeQueueStatusDiverged {
+		t.Fatalf("expected third item diverged at pos3, got status=%s pos=%d", items[2].Status, items[2].Position)
+	}
+}
+
+func TestGetQueueHeadStopsAtDivergence(t *testing.T) {
+	st, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	project := "proj"
+	paths := []string{
+		"/tmp/head-a",
+		"/tmp/head-b",
+		"/tmp/head-c",
+	}
+	branches := []string{"feat/a", "feat/b", "feat/c"}
+
+	for i := range paths {
+		if err := st.UpsertWorktree(&Worktree{
+			Path:    paths[i],
+			Project: project,
+			Branch:  branches[i],
+			IsMain:  false,
+			Status:  WorktreeStatusActive,
+		}); err != nil {
+			t.Fatalf("failed to seed worktree %d: %v", i, err)
+		}
+	}
+
+	seed := []*MergeQueueItem{
+		{
+			ID:           "ha",
+			Project:      project,
+			WorktreePath: paths[0],
+			Branch:       branches[0],
+			BaseBranch:   "main",
+			BaseCommit:   "main0",
+			HeadCommit:   "a1",
+		},
+		{
+			ID:           "hb",
+			Project:      project,
+			WorktreePath: paths[1],
+			Branch:       branches[1],
+			BaseBranch:   branches[0],
+			BaseCommit:   "a1",
+			HeadCommit:   "b1",
+		},
+		{
+			ID:           "hc",
+			Project:      project,
+			WorktreePath: paths[2],
+			Branch:       branches[2],
+			BaseBranch:   branches[1],
+			BaseCommit:   "b1",
+			HeadCommit:   "c1",
+		},
+	}
+	for _, item := range seed {
+		if err := st.AddToMergeQueue(item); err != nil {
+			t.Fatalf("failed to add queue item %s: %v", item.ID, err)
+		}
+	}
+
+	if err := st.UpdateMergeQueueItem(paths[1], MergeQueueStatusDiverged, ""); err != nil {
+		t.Fatalf("failed to mark diverged: %v", err)
+	}
+
+	branch, commit, err := st.GetQueueHead(project)
+	if err != nil {
+		t.Fatalf("GetQueueHead failed: %v", err)
+	}
+	if branch != branches[0] || commit != "a1" {
+		t.Fatalf("expected head to stop at first item (%s,a1), got (%s,%s)", branches[0], branch, commit)
+	}
+}

--- a/internal/worktree/migrate.go
+++ b/internal/worktree/migrate.go
@@ -383,7 +383,7 @@ func (m *Migrator) createTodoFile(worktreePath string, opts CreateWorktreeOption
 	content.WriteString("3. Check queue status: `ath queue`\n\n")
 	content.WriteString("If you need to fix something after adding to queue:\n")
 	content.WriteString("1. Make your changes\n")
-	content.WriteString("2. Run `ath queue bump` to move to back and auto-rebase dependents\n")
+	content.WriteString("2. Run `ath queue bump` to refresh head and reconcile dependents\n")
 	content.WriteString("3. If conflicts occur, resolve them and continue\n")
 
 	content.WriteString("\n---\n")


### PR DESCRIPTION
## Summary\n- keep queue positions stable when an in-progress worktree advances\n- mark downstream entries as diverged and stop integration head at divergence/conflict\n- add merge queue tests for divergence and stable-head behavior\n\n## Why\nThis aligns queue behavior with stacked worktrees in progress: active work keeps its place, divergence is explicit, and only merge-ready flow behaves like a queue.