### PR TITLE
wi-c5a6.5: feat(spawn): pass actionable task prompt to agents at spawn time

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -16,7 +16,10 @@
       "Bash(done)",
       "Bash(__NEW_LINE_600f9fd93018bf85__ echo \"\")",
       "Bash(nc:*)",
-      "Bash(# Check results from all 4 executors for agent_id in f30aa857-7734-43ee-9039-106735481006 86c30166-c00e-4f4c-ba83-c903a7d1c384 dc50cdc2-d926-4011-add0-9de98895e6d5 9d86b7f7-c39a-4b20-999b-b4d72af8a9dd; do echo \"\"=== Agent $agent_id ===\"\" sqlite3 ~/.local/share/athena/athena.db \"\"SELECT substr\\(payload, 1, 300\\) FROM agent_events WHERE agent_id = ''$agent_id'' AND event_type = ''result'';\"\")"
+      "Bash(# Check results from all 4 executors for agent_id in f30aa857-7734-43ee-9039-106735481006 86c30166-c00e-4f4c-ba83-c903a7d1c384 dc50cdc2-d926-4011-add0-9de98895e6d5 9d86b7f7-c39a-4b20-999b-b4d72af8a9dd; do echo \"\"=== Agent $agent_id ===\"\" sqlite3 ~/.local/share/athena/athena.db \"\"SELECT substr\\(payload, 1, 300\\) FROM agent_events WHERE agent_id = ''$agent_id'' AND event_type = ''result'';\"\")",
+      "Bash(./athena changelog add:*)",
+      "Bash(ath changelog add:*)",
+      "Bash(ath --help:*)"
     ]
   }
 }

--- a/internal/daemon/spawn.go
+++ b/internal/daemon/spawn.go
@@ -576,7 +576,33 @@ func (d *Daemon) buildSpawnPrompt(workItem *store.WorkItem, parentGoal *store.Wo
 	b.WriteString("When your work is complete:\n")
 	b.WriteString("1. Ensure all tasks are marked `completed`\n")
 	b.WriteString("2. Commit your changes with a clear message\n")
-	b.WriteString("3. Run `ath queue add` to add this feature to the merge queue\n")
+	b.WriteString("3. Run `ath queue add` to add this feature to the merge queue\n\n")
+
+	// Actionable task prompt - tell the agent what to do
+	b.WriteString("## Your Task\n\n")
+	if retrieve {
+		b.WriteString("Start by exploring the codebase and creating a plan:\n")
+		b.WriteString("1. Understand the current architecture and relevant patterns\n")
+		b.WriteString("2. Break down the work into specific, trackable tasks\n")
+		b.WriteString("3. Use TaskCreate to document each task with clear descriptions\n\n")
+		if workItem.Description != "" {
+			b.WriteString(fmt.Sprintf("Goal: %s\n", workItem.Description))
+		} else if workItem.Subject != "" {
+			b.WriteString(fmt.Sprintf("Goal: %s\n", workItem.Subject))
+		}
+	} else {
+		// Direct execution mode
+		if workItem.Description != "" {
+			b.WriteString(fmt.Sprintf("%s\n\n", workItem.Description))
+		} else if workItem.Subject != "" {
+			b.WriteString(fmt.Sprintf("%s\n\n", workItem.Subject))
+		}
+		b.WriteString("Begin by:\n")
+		b.WriteString("1. Using TaskCreate to break this into specific implementation tasks\n")
+		b.WriteString("2. Exploring relevant code to understand the current implementation\n")
+		b.WriteString("3. Implementing the changes following existing patterns\n")
+		b.WriteString("4. Marking each task in_progress when starting and completed when done\n")
+	}
 
 	return b.String()
 }


### PR DESCRIPTION
## Summary

Agents now receive a clear, actionable task prompt when spawned that allows them to start working immediately without waiting for a follow-up message.

**Changes:**
- Modified `buildSpawnPrompt()` to append a "Your Task" section with the work item description
- Added mode-specific guidance:
  - **Retrieve mode (-r)**: Explore codebase → Create plan → Break into tasks
  - **Executor mode**: Task description → Implementation steps
- Agents now get explicit next steps for using TaskCreate and tracking progress

**Impact:**
- Agents can start working immediately upon spawn
- Clearer onboarding reduces confusion and wasted API calls
- Better user experience for feature development workflow

## Test Plan

- [x] Code builds successfully (`go build ./...`)
- [x] Verified prompt structure includes actionable task section
- [ ] Manual test: Spawn an agent for a feature and verify it starts working without prompting
- [ ] Verify both retrieve mode and executor mode prompts are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)