### PR TITLE
fix(store): handle NULL completed count for items with no descendants

### DIFF
--- a/internal/store/work_items.go
+++ b/internal/store/work_items.go
@@ -287,7 +287,7 @@ func (s *Store) GetWorkItemProgress(itemID string) (completed, total int, err er
 		)
 		SELECT
 			COUNT(*) as total,
-			SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) as completed
+			COALESCE(SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END), 0) as completed
 		FROM descendants`
 
 	row := s.db.QueryRow(query, itemID)


### PR DESCRIPTION
## Summary
- `SUM()` returns NULL on empty result sets in SQLite
- `GetWorkItemProgress` crashed with `sql: Scan error on column index 1, name "completed": converting NULL to int is unsupported` when a work item had no children
- Added `COALESCE(..., 0)` to handle the empty case

## Test plan
- [x] `go test ./internal/store/...` passes
- [x] `ath feat new <goal-id> "description"` no longer crashes