### PR TITLE
chore: gitignore .claude/ and .entire/ tool config dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ go.work.sum
 athena.sock
 
 .todo
+
+# Tool-local config
+.claude/
+.entire/


### PR DESCRIPTION
## Summary

- Adds `.claude/` and `.entire/` to `.gitignore` — these are local tool config directories that shouldn't be tracked